### PR TITLE
Remove empty strings.xml files after creation

### DIFF
--- a/src/main/groovy/be/lukin/poeditor/gradle/POEditorPlugin.groovy
+++ b/src/main/groovy/be/lukin/poeditor/gradle/POEditorPlugin.groovy
@@ -1,6 +1,6 @@
 package be.lukin.poeditor.gradle
 
-import be.lukin.poeditor.tasks.PullTask;
+import be.lukin.poeditor.tasks.PullTaskWithEmptyFileFix;
 import be.lukin.poeditor.tasks.PushTask;
 import be.lukin.poeditor.tasks.PushTermsTask;
 import be.lukin.poeditor.tasks.InitTask;
@@ -121,7 +121,7 @@ class PullTaskGradle extends DefaultTask {
     def initialize() {
         def project = this.getProject();
         POEditorExtension extension = project.poeditor;
-        new PullTask().configure(extension.toConfig()).handle();
+        new PullTaskWithEmptyFileFix().configure(extension.toConfig()).handle();
     }
 }
 

--- a/src/main/groovy/be/lukin/poeditor/tasks/PullTaskWithEmptyFileFix.java
+++ b/src/main/groovy/be/lukin/poeditor/tasks/PullTaskWithEmptyFileFix.java
@@ -1,0 +1,45 @@
+package be.lukin.poeditor.tasks;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import be.lukin.poeditor.Config;
+import be.lukin.poeditor.FileTypeEnum;
+import be.lukin.poeditor.FilterByEnum;
+import be.lukin.poeditor.models.Project;
+
+public final class PullTaskWithEmptyFileFix extends BaseTask {
+
+    @Override
+    public void handle() {
+        System.out.println("Downloading translations");
+        Config config = super.config;
+        Path current = Paths.get("");
+        Project details = client.getProject(config.getProjectId());
+
+        System.out.println("Project: " + details.name + " (id:" + details.id + ", type:" + config.getType() + ")");
+        FileTypeEnum fte = FileTypeEnum.valueOf(config.getType().toUpperCase());
+
+        for (String languageKey : config.getLanguageKeys()) {
+            String path = config.getLanguage(languageKey);
+            File exportFile = new File(current.toAbsolutePath().toString(), path);
+            exportFile.getParentFile().mkdirs();
+            FilterByEnum[] filters = config.getFilters(languageKey);
+
+            File f = client.export(config.getProjectId(), languageKey, fte, filters, exportFile, config.getTagsPull());
+            System.out.println(" - Trans " + languageKey + ": " + path);
+            System.out.println(" - Filters " + languageKey + ": " + Arrays.toString(filters));
+            if (f == null) {
+                System.out.println(" - No file was created");
+            } else if (f.length() == 0) {
+                if (!f.delete()) {
+                    throw new RuntimeException("Failed to delete empty file " + f);
+                }
+                System.out.println(" - File was empty, deleted " + f);
+            }
+            System.out.println();
+        }
+    }
+}


### PR DESCRIPTION
Bug is in the client library, so had to copy and modify the `PullTask` class

This obviously isn't ideal, but the only way to keep this fix in the client library where is should be would be to fork that library too, and have this fork reference the other fork. 

Example:

``` - Trans de-at: app/src/product/res/values-de-rAT/strings.xml
 - Filters de-at: [TRANSLATED]
 - File was empty, deleted /Users/username/Project/app/src/product/res/values-de-rAT/strings.xml

 - Trans nl-nl: app/src/product/res/values-nl-rNL/strings.xml
 - Filters nl-nl: [TRANSLATED]
 - No file was created

 - Trans nb: app/src/product/res/values-nb/strings.xml
 - Filters nb: [TRANSLATED]
 - File was empty, deleted /Users/username/Project/app/src/product/res/values-nb/strings.xml

 - Trans fr-ch: app/src/product/res/values-fr-rCH/strings.xml
 - Filters fr-ch: [TRANSLATED]
 - File was empty, deleted /Users/username/Project/app/src/product/res/values-fr-rCH/strings.xml

 - Trans it-ch: app/src/product/res/values-it-rCH/strings.xml
 - Filters it-ch: [TRANSLATED]
 - File was empty, deleted /Users/username/Project/app/src/product/res/values-it-rCH/strings.xml

 - Trans pl: app/src/product/res/values-pl/strings.xml
 - Filters pl: [TRANSLATED]

 - Trans da: app/src/product/res/values-da/strings.xml
 - Filters da: [TRANSLATED]

 - Trans de-ch: app/src/product/res/values-de-rCH/strings.xml
 - Filters de-ch: [TRANSLATED]
 - File was empty, deleted /Users/username/Project/app/src/product/res/values-de-rCH/strings.xml
```